### PR TITLE
* Fix '#define NEW_SORTING_CODE 1' on ARM.

### DIFF
--- a/common/math/SSE2NEON.h
+++ b/common/math/SSE2NEON.h
@@ -1383,12 +1383,10 @@ FORCE_INLINE void _mm_clflush(void const*p)
 	// no corollary for Neon?
 }
 
-//
-// NOTE(LTE): Missing SSE2 functions in original SSE2NEON.h
-//
 FORCE_INLINE __m128i _mm_set_epi64x(int64_t a, int64_t b)
 {
-	int64_t __attribute__((aligned(16))) data[2] = { a, b };
+	// Stick to the flipped behavior of x86.
+	int64_t __attribute__((aligned(16))) data[2] = { b, a };
 	return (__m128i)vld1q_s64(data);
 }
 

--- a/common/math/math.h
+++ b/common/math/math.h
@@ -89,7 +89,6 @@ namespace embree
   }
   __forceinline float rsqrt( const float x )
   {
-#if 0
     const __m128 a = _mm_set_ss(x);
 #if defined(__AVX512VL__)
     const __m128 r = _mm_rsqrt14_ss(_mm_set_ss(0.0f),a);
@@ -99,13 +98,6 @@ namespace embree
     const __m128 c = _mm_add_ss(_mm_mul_ss(_mm_set_ss(1.5f), r),
                                 _mm_mul_ss(_mm_mul_ss(_mm_mul_ss(a, _mm_set_ss(-0.5f)), r), _mm_mul_ss(r, r)));
     return _mm_cvtss_f32(c);
-#else
-    if (x > 0.0f) {
-      return 1.0f / std::sqrt(x);
-    } else {
-      return 0.0f;
-    }
-#endif
   }
 
 #if defined(__WIN32__) && (__MSC_VER <= 1700)

--- a/common/simd/vint4_sse2.h
+++ b/common/simd/vint4_sse2.h
@@ -458,7 +458,7 @@ namespace embree
 #if defined(__WIN32__) && !defined(__X86_64__) // win32 workaround
     return toScalar(v);
 #elif defined(__ARM_NEON)
-    return vgetq_lane_s32(v, 0);
+    return vgetq_lane_u64(v, 0);
 #else
     return _mm_cvtsi128_si64(v); 
 #endif

--- a/kernels/bvh/bvh_traverser1.h
+++ b/kernels/bvh/bvh_traverser1.h
@@ -20,13 +20,7 @@
 #include "node_intersector1.h"
 #include "../common/stack_item.h"
 
-#if defined(__aarch64__)
-// FIXME(LTE): Enabling `NEW_SORTING_CODE` will generate corrupted BVH node.
-// toSizeT in traverseClosestHit() passes invalid node(ptr) value and isAlignedNode() assertion will be triggered in later intersect() function.
-#define NEW_SORTING_CODE 0
-#else
 #define NEW_SORTING_CODE 1
-#endif
 
 namespace embree
 {

--- a/kernels/geometry/cylinder.h
+++ b/kernels/geometry/cylinder.h
@@ -131,12 +131,8 @@ namespace embree
         passed &= verify(0,cylinder,RayHit(Vec3fa(-2.0f,1.0f,0.0f),Vec3fa( 0.0f,-1.0f,+0.0f),0.0f,float(inf)),true,0.0f,2.0f);
         passed &= verify(1,cylinder,RayHit(Vec3fa(+2.0f,1.0f,0.0f),Vec3fa( 0.0f,-1.0f,+0.0f),0.0f,float(inf)),true,0.0f,2.0f);
         passed &= verify(2,cylinder,RayHit(Vec3fa(+2.0f,1.0f,2.0f),Vec3fa( 0.0f,-1.0f,+0.0f),0.0f,float(inf)),false,0.0f,0.0f);
-        // FIXME(LTE): Disable failed tests for a while.
-        // TODO(LTE): Investigate the reason
-#if !defined(__ARM_NEON)
         passed &= verify(3,cylinder,RayHit(Vec3fa(+0.0f,0.0f,0.0f),Vec3fa( 1.0f, 0.0f,+0.0f),0.0f,float(inf)),true,neg_inf,pos_inf);
         passed &= verify(4,cylinder,RayHit(Vec3fa(+0.0f,0.0f,0.0f),Vec3fa(-1.0f, 0.0f,+0.0f),0.0f,float(inf)),true,neg_inf,pos_inf);
-#endif
         passed &= verify(5,cylinder,RayHit(Vec3fa(+0.0f,2.0f,0.0f),Vec3fa( 1.0f, 0.0f,+0.0f),0.0f,float(inf)),false,pos_inf,neg_inf);
         passed &= verify(6,cylinder,RayHit(Vec3fa(+0.0f,2.0f,0.0f),Vec3fa(-1.0f, 0.0f,+0.0f),0.0f,float(inf)),false,pos_inf,neg_inf);
         return passed;


### PR DESCRIPTION
The issue was caused by packing the tuple (size_t node*, float32 tnear) in reverse order, see
https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_set_epi64x&expand=4902

This addresses the issue:
https://github.com/lighttransport/embree-aarch64/issues/2